### PR TITLE
potential fix for #308

### DIFF
--- a/.github/workflows/build-workspace.yml
+++ b/.github/workflows/build-workspace.yml
@@ -202,7 +202,7 @@ jobs:
       run: |
         pkgbuild --install-location /Applications --component build/ntsc-rs-standalone/ntsc-rs.app --min-os-version $MACOSX_DEPLOYMENT_TARGET --compression latest build/ntsc-rs-macos-standalone.pkg
         pkgbuild --install-location /Library/OFX/Plugins --component build/ntsc-rs-openfx/NtscRs.ofx.bundle --min-os-version $MACOSX_DEPLOYMENT_TARGET --compression latest build/ntsc-rs-macos-openfx.pkg
-        pkgbuild --install-location "/Library/Application Support/Adobe/Common/Plug-ins/7.0/MediaCore" --component build/ntsc-rs-afterfx/ntsc-rs.plugin --min-os-version $MACOSX_DEPLOYMENT_TARGET --compression latest build/ntsc-rs-macos-afterfx.pkg
+        pkgbuild --install-location "/Library/Application Support/Adobe/Common/Plug-ins/7.0/MediaCore" --component build/ntsc-rs-afterfx/ntsc-rs.plugin --min-os-version $MACOSX_DEPLOYMENT_TARGET --scripts assets/install_scripts --compression latest build/ntsc-rs-macos-afterfx.pkg
 
     - name: Archive .pkg installers
       uses: actions/upload-artifact@v4

--- a/assets/install_scripts/postinstall
+++ b/assets/install_scripts/postinstall
@@ -1,9 +1,11 @@
 #!/usr/bin/env sh
 set -e
 
-if [ -d "/Library/Application Support/Adobe/Common/Plug-ins/7.0/MediaCore/ntsc-rs.plugin" ]; then
+PLUGIN_BUNDLE="$DSTROOT/ntsc-rs.plugin"
+
+if [ -d "$PLUGIN_BUNDLE" ]; then
     echo "Signing After Effects plugin with ad-hoc signature..."
-    /usr/bin/codesign --force --deep --sign - "/Library/Application Support/Adobe/Common/Plug-ins/7.0/MediaCore/ntsc-rs.plugin"
+    /usr/bin/codesign --force --deep --sign - "$PLUGIN_BUNDLE"
     echo "After Effects plugin signed successfully."
 else
     echo "After Effects plugin not found at expected location. Skipping signing."

--- a/assets/install_scripts/postinstall
+++ b/assets/install_scripts/postinstall
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env sh
+set -e
 
 if [ -d "/Library/Application Support/Adobe/Common/Plug-ins/7.0/MediaCore/ntsc-rs.plugin" ]; then
     echo "Signing After Effects plugin with ad-hoc signature..."

--- a/assets/install_scripts/postinstall
+++ b/assets/install_scripts/postinstall
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ -d "/Library/Application Support/Adobe/Common/Plug-ins/7.0/MediaCore/ntsc-rs.plugin" ]; then
+    echo "Signing After Effects plugin with ad-hoc signature..."
+    /usr/bin/codesign --force --deep --sign - "/Library/Application Support/Adobe/Common/Plug-ins/7.0/MediaCore/ntsc-rs.plugin"
+    echo "After Effects plugin signed successfully."
+else
+    echo "After Effects plugin not found at expected location. Skipping signing."
+    exit 1
+fi
+
+exit 0

--- a/xtask/src/build_ofx_plugin.rs
+++ b/xtask/src/build_ofx_plugin.rs
@@ -89,7 +89,7 @@ fn get_info_plist() -> plist::Value {
     );
     info_plist_contents.insert(
         "NSHumanReadableCopyright".to_string(),
-        plist::Value::from("© 2023-2024 valadaptive"),
+        plist::Value::from("© 2023-2025 valadaptive"),
     );
     info_plist_contents.insert("CFBundleSignature".to_string(), plist::Value::from("????"));
 

--- a/xtask/src/macos_bundle.rs
+++ b/xtask/src/macos_bundle.rs
@@ -150,7 +150,7 @@ pub fn main(args: &clap::ArgMatches) -> Result<(), Box<dyn Error>> {
     );
     info_plist_contents.insert(
         "NSHumanReadableCopyright".to_string(),
-        plist::Value::from("© 2023-2024 valadaptive"),
+        plist::Value::from("© 2023-2025 valadaptive"),
     );
     info_plist_contents.insert("CFBundleSignature".to_string(), plist::Value::from("????"));
 


### PR DESCRIPTION
This is a janky move and bad in practice, it signs the package with an ad hoc signature, the same way one would develop if they didn't have a developer account. However it removes the constraint of the maintainers needing an apple developer account. I have tested this with AE 25.3.0 Beta and the plugin can now load normally.